### PR TITLE
Add library metadata for use in PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,19 @@
+{
+  "name": "WDT_T4",
+  "frameworks": "Arduino",
+  "platforms": "Teensy",
+  "keywords": "watchdog",
+  "description": "Watchdog for Teensy 4, WDOG1,2,3, and EWM",
+  "homepage": "https://forum.pjrc.com/threads/59257-WDT_T4-Watchdog-Library-for-Teensy-4",
+  "authors":
+  {
+    "name": "Antonio Brewer",
+    "maintainer": true
+  },
+  "repository":
+  {
+      "type": "git",
+      "url": "https://github.com/tonton81/WDT_T4.git"
+  },
+  "version": "0.1"
+}

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=WDT_T4
+version=0.1
+author=Antonio Brewer
+maintainer=Antonio Brewer
+sentence=Watchdog for Teensy 4, WDOG1,2,3, and EWM
+paragraph=Watchdog for Teensy 4, WDOG1,2,3, and EWM
+category=Watchdog
+url=https://forum.pjrc.com/threads/59257-WDT_T4-Watchdog-Library-for-Teensy-4
+architectures=teensy


### PR DESCRIPTION
Should work for the Arduino IDE too, though I haven't tried it.